### PR TITLE
Implement m1/m2 speed reading

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,10 +340,28 @@ impl <S: SerialPort + Sized> Roboclaw<S> {
         unimplemented!()
     }
 
-    /*
-    uint32_t ReadSpeedM1(uint8_t address, uint8_t *status=NULL,bool *valid=NULL);
-    uint32_t ReadSpeedM2(uint8_t address, uint8_t *status=NULL,bool *valid=NULL);
-    */
+    //uint32_t ReadSpeedM1(uint8_t address, uint8_t *status=NULL,bool *valid=NULL);
+    pub fn read_speed_m1(&mut self) -> Result<(u32, u8), std::io::Error> {
+        self.read_command(Command::GETM1SPEED as u8, 5)
+            .map(|data| {
+                (
+                    join_u8_u32(data[0], data[1], data[2], data[3]),
+                    data[4],
+                )
+            })
+    }
+
+    //uint32_t ReadSpeedM2(uint8_t address, uint8_t *status=NULL,bool *valid=NULL);
+    pub fn read_speed_m2(&mut self) -> Result<(u32, u8), std::io::Error> {
+        self.read_command(Command::GETM2SPEED as u8, 5)
+            .map(|data| {
+                (
+                    join_u8_u32(data[0], data[1], data[2], data[3]),
+                    data[4],
+                )
+            })
+    }
+
     //bool ResetEncoders(uint8_t address);
     pub fn reset_encoders(&mut self) -> Result<(), std::io::Error> {
         self.write_simple_command(Command::RESETENC as u8)


### PR DESCRIPTION
Just wanted to mention thank you for this project! It helped me move a critical part of my robot to rust.

This implements the speed reading fns. I tried to keep to the style of the code. It worked when I used it, although that was for a fairly brief while since I no longer have the encoders wired up. But maybe it's useful for others!

Two numbers are returned:
* The speed as u32 (measured in [encoder pulse edges](https://forums.basicmicro.com/viewtopic.php?t=812).)
* The status as u8 (docs aren't clear about what this means though.)
